### PR TITLE
HH-132947 Fix URL-decoding OAuth "state" parameter in callback

### DIFF
--- a/.hh-release.yaml
+++ b/.hh-release.yaml
@@ -1,5 +1,5 @@
 docker_files:
   httpemulator: httpemulator-server/docker/Dockerfile
-build_image: registry.pyn.ru/openjdk11-building:2019.04.04
+build_image: registry.pyn.ru/openjdk15-building:2021.05.26
 build_method: mvn_build
 update_method: mvn_update

--- a/httpemulator-client/pom.xml
+++ b/httpemulator-client/pom.xml
@@ -18,6 +18,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/httpemulator-server/docker/Dockerfile
+++ b/httpemulator-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.pyn.ru/openjdk11-production:2019.04.04 
+FROM registry.pyn.ru/openjdk15-production:2021.05.26
 
 ENV LANG="en_US.UTF-8"
 

--- a/httpemulator-server/pom.xml
+++ b/httpemulator-server/pom.xml
@@ -15,6 +15,7 @@
     <name>httpemulator-server</name>
 
     <properties>
+        <!--suppress UnresolvedMavenProperty -->
         <target-test-stand>${env.TARGET_TEST_STAND}</target-test-stand>
     </properties>
 
@@ -120,8 +121,7 @@
                         </goals>
                         <configuration>
                             <finalName>httpemulator</finalName>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            <transformers combine.children="append">
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>ru.hh.httpemulator.server.Launcher</Main-Class>
@@ -134,16 +134,6 @@
                                     <resource>META-INF/spring.schemas</resource>
                                 </transformer>
                             </transformers>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/httpemulator-server/src/etc/stand-config.properties
+++ b/httpemulator-server/src/etc/stand-config.properties
@@ -1,11 +1,2 @@
-docker/hhid/application_host=dev.pyn.ru
-docker/hhid/application_port=9100
-docker/postgresql/application_host=dev-db2.pyn.ru
-docker/postgresql/application_port=5432
-haproxy/front-memcached/application_host=dev.pyn.ru
-haproxy/front-memcached/application_port=11211
-docker/qsite/application_host=dev.pyn.ru
-docker/qsite/application_port=5672
-docker/cassandra/application_host=dev.pyn.ru
-docker/cassandra-hhid/application_host=dev.pyn.ru
-docker/cassandra-hhid/application_port=9142
+docker/httpemulator/application_host=dev.pyn.ru
+docker/httpemulator/application_port=18800

--- a/httpemulator-server/src/main/java/ru/hh/httpemulator/server/scenario/OAuthCodeCallbackScenario.java
+++ b/httpemulator-server/src/main/java/ru/hh/httpemulator/server/scenario/OAuthCodeCallbackScenario.java
@@ -1,5 +1,7 @@
 package ru.hh.httpemulator.server.scenario;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
@@ -27,8 +29,9 @@ public class OAuthCodeCallbackScenario implements Scenario {
           .filter(httpEntry -> OAUTH_REDIRECT_URI_KEY.equals(httpEntry.getKey()))
           .map(HttpEntry::getValue)
           .findFirst()
-          .ifPresent(oauthRedirectUri
-              -> response.header("Location", oauthRedirectUri + (oauthRedirectUri.indexOf('?') == -1 ? '?' : '&') + "state=" + state));
+          .ifPresent(oauthRedirectUri -> response.header(
+              "Location",
+              oauthRedirectUri + (oauthRedirectUri.indexOf('?') == -1 ? '?' : '&') + "state=" + URLEncoder.encode(state, StandardCharsets.UTF_8)));
     }
 
     response.status(HttpServletResponse.SC_MOVED_TEMPORARILY);

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>ru.hh.public-pom</groupId>
         <artifactId>public-pom</artifactId>
-        <version>1.36</version>
+        <version>1.49</version>
     </parent>
 
     <modules>
@@ -18,25 +18,4 @@
         <module>httpemulator-client</module>
     </modules>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
-            </plugin>
-            <plugin>
-                <groupId>ru.hh.checkstyle</groupId>
-                <artifactId>hh-maven-checkstyle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-132947

Автотесты на соцсети сейчас работают чудом, потому что нездорово написанный код в ххиде маскирует ошибку эмулятора. Значение параметра state, которое изначально имеет вид `token=...&reg=...&fail=...` , передается в URL-encoded виде как единый параметр, а в эмуляторе оно декодируется и в результате разваливается на множество параметров.